### PR TITLE
little fix for IndexOfSequence function

### DIFF
--- a/sources/CodeBits_Net30/ByteArrayHelper.cs
+++ b/sources/CodeBits_Net30/ByteArrayHelper.cs
@@ -156,8 +156,13 @@ namespace CodeBits
                     sequenceIndex++;
                     if (sequenceIndex >= sequence.Length)
                         return byteIdx - sequence.Length + 1;
-                } else
+                }
+                else
+                {
+                    if (sequenceIndex > 0)
+                        byteIdx = byteIdx - sequenceIndex;
                     sequenceIndex = 0;
+                }
             }
             return -1;
         }


### PR DESCRIPTION
when searching bit after bit, when couple of bits of sequence are the same and the next bit is not the same, so the sequence eventually fails to match, you have to come back searching to the begining point + 1 of previous part match, because otherwise you could miss the match in special situation when the valid match starts in the middle of that failed part match